### PR TITLE
Update default text color to #070B17

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
 :root {
   --bg: #0b0f16;
   --card: #111827;
-  --text: #e6f2ff;
+  --text: #070B17;
   --accent: #9AE6B4;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
           bg: "#0b0f16",
           card: "#111827",
           accent: "#9AE6B4",
-          soft: "#e6f2ff"
+          soft: "#070B17"
         }
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- change global `--text` variable to `#070B17`
- adjust Tailwind `soft` color to match

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b684219883209ddc6224332f7ee7