### PR TITLE
chore: integrate Inter font with Tailwind

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import "./globals.css";
 import type { ReactNode } from "react";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata = {
   title: "Horse Coat Color Calculator",
@@ -11,7 +14,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={`${inter.className} ${inter.variable}`}>{children}</body>
     </html>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
           soft: "#070B17"
         }
       },
+      fontFamily: {
+        sans: ["var(--font-inter)", "sans-serif"],
+      },
       boxShadow: {
         'glow': '0 0 40px rgba(154, 230, 180, 0.25)'
       }


### PR DESCRIPTION
## Summary
- import and apply Inter font globally
- extend Tailwind font family to use Inter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b8a2fc088320a0753cb63e50640a