### PR TITLE
feat: adopt light background palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,16 +3,16 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0b0f16;
-  --card: #111827;
+  --bg: #f8fafc;
+  --card: #ffffff;
   --text: #070B17;
-  --accent: #9AE6B4;
+  --accent: #16a34a;
 }
 
 html, body, #__next { height: 100%; }
 body {
-  background: radial-gradient(1200px 800px at 80% -10%, rgba(154,230,180,0.15), transparent 50%),
-              radial-gradient(1200px 800px at -10% 80%, rgba(230,242,255,0.08), transparent 50%),
+  background: radial-gradient(1200px 800px at 80% -10%, rgba(22,163,74,0.15), transparent 50%),
+              radial-gradient(1200px 800px at -10% 80%, rgba(59,130,246,0.1), transparent 50%),
               var(--bg);
   color: var(--text);
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,22 +6,22 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: "sm" | "md" | "lg";
 };
 
-export function Button({ className, variant = "default", size = "md", ...props }: ButtonProps) {
-  const variants = {
-    default: "bg-white/5 hover:bg-white/10 border border-white/10",
-    outline: "bg-transparent border border-white/20 hover:bg-white/5",
-    ghost: "bg-transparent hover:bg-white/5",
-    secondary: "bg-white/5 hover:bg-white/10 border border-white/20"
-  };
-  const sizes = {
-    sm: "px-3 py-1.5 text-sm rounded-md",
-    md: "px-4 py-2 text-base rounded-lg",
-    lg: "px-5 py-3 text-lg rounded-xl"
-  };
-  return (
-    <button
-      className={cn("text-white transition shadow-glow", variants[variant], sizes[size], className)}
-      {...props}
-    />
-  );
-}
+  export function Button({ className, variant = "default", size = "md", ...props }: ButtonProps) {
+    const variants = {
+      default: "bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90 border border-[var(--accent)]",
+      outline: "bg-transparent border border-[var(--accent)] text-[var(--text)] hover:bg-[var(--accent)]/10",
+      ghost: "bg-transparent text-[var(--text)] hover:bg-gray-100",
+      secondary: "bg-gray-100 hover:bg-gray-200 text-[var(--text)] border border-gray-200"
+    };
+    const sizes = {
+      sm: "px-3 py-1.5 text-sm rounded-md",
+      md: "px-4 py-2 text-base rounded-lg",
+      lg: "px-5 py-3 text-lg rounded-xl"
+    };
+    return (
+      <button
+        className={cn("transition shadow-glow", variants[variant], sizes[size], className)}
+        {...props}
+      />
+    );
+  }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,7 +2,15 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("bg-[var(--card)]/80 backdrop-blur border border-white/10 rounded-2xl p-6", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "bg-[var(--card)] border border-gray-200 rounded-2xl p-6",
+        className
+      )}
+      {...props}
+    />
+  );
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,17 +4,17 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        glam: {
-          bg: "#0b0f16",
-          card: "#111827",
-          accent: "#9AE6B4",
-          soft: "#070B17"
+          glam: {
+            bg: "#f8fafc",
+            card: "#ffffff",
+            accent: "#16a34a",
+            soft: "#070B17"
+          }
+        },
+        boxShadow: {
+          'glow': '0 0 40px rgba(22, 163, 74, 0.25)'
         }
       },
-      boxShadow: {
-        'glow': '0 0 40px rgba(154, 230, 180, 0.25)'
-      }
-    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- switch global theme to light background with updated radial gradients
- sync Tailwind glam colors and glow shadow with new light palette
- refine card and button styling for clear contrast on light theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0b8afa3e88320bb2c0c7a26337d12