### PR TITLE
Import Metadata type

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,11 @@
 import "./globals.css";
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Horse Coat Color Calculator",
   description: "A glam UI to explore horse coat genetics",
   manifest: "/manifest.json",


### PR DESCRIPTION
## Summary
- import Metadata from Next.js and annotate metadata object

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68c0d965f0408320b70086eea6451506