### PR TITLE
style: improve readability

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "CoatCalc",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0b0f16",
-  "theme_color": "#e6f2ff",
+  "background_color": "#f9fafb",
+  "theme_color": "#9AE6B4",
   "icons": [
     {
       "src": "/icons/icon-192.png",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,10 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0b0f16;
-  --card: #111827;
-  --text: #070B17;
+  /* Light theme colors for improved readability */
+  --bg: #f9fafb;
+  --card: #ffffff;
+  --text: #1a202c;
   --accent: #9AE6B4;
 }
 
@@ -15,6 +16,7 @@ body {
               radial-gradient(1200px 800px at -10% 80%, rgba(230,242,255,0.08), transparent 50%),
               var(--bg);
   color: var(--text);
+  @apply text-lg;
 }
 
 .container {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,7 +2,15 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("bg-[var(--card)]/80 backdrop-blur border border-white/10 rounded-2xl p-6", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "bg-[var(--card)]/80 backdrop-blur border border-black/10 rounded-2xl p-6",
+        className
+      )}
+      {...props}
+    />
+  );
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,10 +5,10 @@ module.exports = {
     extend: {
       colors: {
         glam: {
-          bg: "#0b0f16",
-          card: "#111827",
+          bg: "#f9fafb",
+          card: "#ffffff",
           accent: "#9AE6B4",
-          soft: "#070B17"
+          soft: "#1a202c"
         }
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- switch to a light background theme and larger default text for easier reading
- sync Tailwind colors and manifest to new scheme
- adjust card border to suit light styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0dfc5759883209c4f8be6a9efd0c1