### PR TITLE
Use splash white and overo bay vectors

### DIFF
--- a/src/components/HorseColorCalculator.tsx
+++ b/src/components/HorseColorCalculator.tsx
@@ -346,7 +346,7 @@ export default function HorseColorCalculator() {
 
           <div className="lg:col-span-1 space-y-6">
             <Section title="Predicted phenotype" defaultOpen={true}>
-              <HorseImage baseColor={phenotype.baseColor} />
+              <HorseImage baseColor={phenotype.baseColor} tags={phenotype.tags} />
               <div className="text-2xl leading-snug text-center">{phenotype.text || "—"}</div>
 
               {phenotype.tags && phenotype.tags.length > 0 ? (

--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -6,13 +6,20 @@ const IMAGE_MAP: Record<string, string> = {
   Black: "/horse/black.svg",
 };
 
-function getImage(name?: string) {
-  if (!name) return undefined;
-  return IMAGE_MAP[name];
+function getImage(baseColor?: string, tags: string[] = []) {
+  if (!baseColor) return undefined;
+  if (baseColor === "Bay") {
+    const hasSplash = tags.includes("Splashed White");
+    const hasOvero = tags.includes("Frame Overo");
+    if (hasSplash && hasOvero) return "/horse/SW1 overo bay.svg";
+    if (hasSplash) return "/horse/SW1 bay.svg";
+    if (hasOvero) return "/horse/overo bay.svg";
+  }
+  return IMAGE_MAP[baseColor];
 }
 
-export default function HorseImage({ baseColor }: { baseColor?: string }) {
-  const src = getImage(baseColor);
+export default function HorseImage({ baseColor, tags = [] }: { baseColor?: string; tags?: string[] }) {
+  const src = getImage(baseColor, tags);
   if (!src) return null;
   return (
     <div className="w-full mb-4 flex items-center justify-center rounded-2xl border bg-white/80 shadow-sm p-4">


### PR DESCRIPTION
## Summary
- show SW1 bay artwork when bay horses carry splash white
- display SW1 overo bay when both splash white and frame overo are present
- pass phenotype tags into HorseImage for pattern-aware images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2107ca4e08320a2a1a0992f07ae3a