### PR TITLE
Add bay roan vector images

### DIFF
--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -11,6 +11,11 @@ function getImage(baseColor?: string, tags: string[] = []) {
   if (baseColor === "Bay") {
     const hasSplash = tags.includes("Splashed White");
     const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasRoan) {
+      if (hasSplash) return "/horse/SW1 bay roan.svg";
+      return "/horse/bay roan.svg";
+    }
     if (hasSplash && hasOvero) return "/horse/SW1 overo bay.svg";
     if (hasSplash) return "/horse/SW1 bay.svg";
     if (hasOvero) return "/horse/overo bay.svg";


### PR DESCRIPTION
## Summary
- support bay roan coat image
- support bay roan with splash white image

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c21d9fadac83209234b61b5776015e