### PR TITLE
Handle bay roan overo image selection

### DIFF
--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -13,6 +13,10 @@ function getImage(baseColor?: string, tags: string[] = []) {
     const hasOvero = tags.includes("Frame Overo");
     const hasRoan = tags.includes("Roan");
     if (hasRoan) {
+      if (hasOvero) {
+        if (hasSplash) return "/horse/SW1 overo bay.svg";
+        return "/horse/overo bay.svg";
+      }
       if (hasSplash) return "/horse/SW1 bay roan.svg";
       return "/horse/bay roan.svg";
     }


### PR DESCRIPTION
## Summary
- ensure bay roan overo horses display Overo bay image
- choose SW1 overo bay image when splashed white is present

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c24f0b804c832098004470d604f8e0