### PR TITLE
Map additional coat colors to horse vectors

### DIFF
--- a/src/components/HorseColorCalculator.tsx
+++ b/src/components/HorseColorCalculator.tsx
@@ -346,7 +346,7 @@ export default function HorseColorCalculator() {
 
           <div className="lg:col-span-1 space-y-6">
             <Section title="Predicted phenotype" defaultOpen={true}>
-              <HorseImage baseColor={phenotype.baseColor} tags={phenotype.tags} />
+              <HorseImage colorName={phenotype.colorName} tags={phenotype.tags} />
               <div className="text-2xl leading-snug text-center">{phenotype.text || "—"}</div>
 
               {phenotype.tags && phenotype.tags.length > 0 ? (

--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -4,11 +4,18 @@ const IMAGE_MAP: Record<string, string> = {
   Chestnut: "/horse/chestnut.svg",
   Bay: "/horse/bay.svg",
   Black: "/horse/black.svg",
+  "Amber Champagne": "/horse/Amber Champagne.svg",
+  "Classic Champagne": "/horse/Classic Champagne.svg",
+  Cremello: "/horse/Classic Champagne.svg",
 };
 
-function getImage(baseColor?: string, tags: string[] = []) {
-  if (!baseColor) return undefined;
-  if (baseColor === "Bay") {
+function getImage(colorName?: string, tags: string[] = []) {
+  if (!colorName) return undefined;
+  if (colorName === "Bay Dun") {
+    if (tags.includes("Roan")) return "/horse/Dun roan.svg";
+    return "/horse/Dun.svg";
+  }
+  if (colorName === "Bay") {
     const hasSplash = tags.includes("Splashed White");
     const hasOvero = tags.includes("Frame Overo");
     const hasRoan = tags.includes("Roan");
@@ -24,16 +31,16 @@ function getImage(baseColor?: string, tags: string[] = []) {
     if (hasSplash) return "/horse/SW1 bay.svg";
     if (hasOvero) return "/horse/overo bay.svg";
   }
-  return IMAGE_MAP[baseColor];
+  return IMAGE_MAP[colorName];
 }
 
-export default function HorseImage({ baseColor, tags = [] }: { baseColor?: string; tags?: string[] }) {
-  const src = getImage(baseColor, tags);
+export default function HorseImage({ colorName, tags = [] }: { colorName?: string; tags?: string[] }) {
+  const src = getImage(colorName, tags);
   if (!src) return null;
   return (
     <div className="w-full mb-4 flex items-center justify-center rounded-2xl border bg-white/80 shadow-sm p-4">
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={src} alt={`${baseColor} horse`} className="w-64 h-64" />
+      <img src={src} alt={`${colorName} horse`} className="w-64 h-64" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- map Amber Champagne, Classic Champagne, Cremello, Bay Dun, and Bay Dun Roan to the correct horse SVGs
- switch HorseImage to use phenotype color name and support new mappings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive setup prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2538e621c83209c009e05ad0882c2