### PR TITLE
Map additional horse coat colors to vector images

### DIFF
--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -12,8 +12,14 @@ const IMAGE_MAP: Record<string, string> = {
 function getImage(colorName?: string, tags: string[] = []) {
   if (!colorName) return undefined;
   if (colorName === "Bay Dun") {
+    if (tags.includes("Frame Overo")) return "/horse/Overo Dun.svg";
     if (tags.includes("Roan")) return "/horse/Dun roan.svg";
     return "/horse/Dun.svg";
+  }
+  if (colorName === "Grullo") {
+    if (tags.includes("Frame Overo")) return "/horse/Overo Grullo.svg";
+    if (tags.includes("Roan")) return "/horse/Grullo Roan.svg";
+    return "/horse/Grullo.svg";
   }
   if (colorName === "Bay") {
     const hasSplash = tags.includes("Splashed White");
@@ -30,6 +36,13 @@ function getImage(colorName?: string, tags: string[] = []) {
     if (hasSplash && hasOvero) return "/horse/SW1 overo bay.svg";
     if (hasSplash) return "/horse/SW1 bay.svg";
     if (hasOvero) return "/horse/overo bay.svg";
+  }
+  if (colorName === "Chestnut") {
+    if (tags.includes("Frame Overo")) return "/horse/Overo chestnut.svg";
+  }
+  if (colorName.includes("Pearl")) {
+    if (tags.includes("Frame Overo")) return "/horse/Overo Pearl or Cream pearl.svg";
+    return "/horse/Pearl or Cream pearl.svg";
   }
   return IMAGE_MAP[colorName];
 }


### PR DESCRIPTION
## Summary
- add vector mapping for Grullo, Grullo Roan, and Overo Grullo coats
- handle Overo Bay Dun, Overo Chestnut, and Pearl variants

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68c258214d788320b60c21e8f82643fd