### PR TITLE
Map cremello and buckskin variants to correct vectors

### DIFF
--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -6,11 +6,15 @@ const IMAGE_MAP: Record<string, string> = {
   Black: "/horse/black.svg",
   "Amber Champagne": "/horse/Amber Champagne.svg",
   "Classic Champagne": "/horse/Classic Champagne.svg",
-  Cremello: "/horse/Classic Champagne.svg",
+  Cremello: "/horse/Cremello.svg",
+  Buckskin: "/horse/buckskin.svg",
 };
 
 function getImage(colorName?: string, tags: string[] = []) {
   if (!colorName) return undefined;
+  if (colorName === "Cremello") {
+    return "/horse/Cremello.svg";
+  }
   if (colorName === "Bay Dun") {
     if (tags.includes("Frame Overo")) return "/horse/Overo Dun.svg";
     if (tags.includes("Roan")) return "/horse/Dun roan.svg";
@@ -39,6 +43,13 @@ function getImage(colorName?: string, tags: string[] = []) {
   }
   if (colorName === "Chestnut") {
     if (tags.includes("Frame Overo")) return "/horse/Overo chestnut.svg";
+  }
+  if (colorName === "Buckskin") {
+    const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasRoan) return "/horse/buckskin roan.svg";
+    if (hasOvero) return "/horse/overo buckskin.svg";
+    return "/horse/buckskin.svg";
   }
   if (colorName.includes("Pearl")) {
     if (tags.includes("Frame Overo")) return "/horse/Overo Pearl or Cream pearl.svg";


### PR DESCRIPTION
## Summary
- Use dedicated vector for cremello regardless of pattern tags
- Map buckskin, buckskin roan, and buckskin overo colors to correct horse SVGs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration and does not run)*

------
https://chatgpt.com/codex/tasks/task_e_68c25be2dec88320a34ac7a43a7c1d04