### PR TITLE
feat: expand horse coat image mappings

### DIFF
--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -8,6 +8,9 @@ const IMAGE_MAP: Record<string, string> = {
   "Classic Champagne": "/horse/Classic Champagne.svg",
   Cremello: "/horse/Cremello.svg",
   Buckskin: "/horse/buckskin.svg",
+  Palomino: "/horse/palomino.svg",
+  "Silver Buckskin": "/horse/silver buckskin.svg",
+  "Silver Bay": "/horse/Silver bay.svg",
 };
 
 function getImage(colorName?: string, tags: string[] = []) {
@@ -42,7 +45,18 @@ function getImage(colorName?: string, tags: string[] = []) {
     if (hasOvero) return "/horse/overo bay.svg";
   }
   if (colorName === "Chestnut") {
-    if (tags.includes("Frame Overo")) return "/horse/Overo chestnut.svg";
+    const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasRoan) return "/horse/chestnut roan.svg";
+    if (hasOvero) return "/horse/Overo chestnut.svg";
+    return "/horse/chestnut.svg";
+  }
+  if (colorName === "Black") {
+    const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasRoan) return "/horse/black roan.svg";
+    if (hasOvero) return "/horse/overo black.svg";
+    return "/horse/black.svg";
   }
   if (colorName === "Buckskin") {
     const hasOvero = tags.includes("Frame Overo");
@@ -50,6 +64,31 @@ function getImage(colorName?: string, tags: string[] = []) {
     if (hasRoan) return "/horse/buckskin roan.svg";
     if (hasOvero) return "/horse/overo buckskin.svg";
     return "/horse/buckskin.svg";
+  }
+  if (colorName === "Palomino") {
+    const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasRoan) return "/horse/palomino roan.svg";
+    if (hasOvero) return "/horse/overo palomino.svg";
+    return "/horse/palomino.svg";
+  }
+  if (colorName === "Silver Buckskin") {
+    const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasRoan) return "/horse/silver buckskin roan.svg";
+    if (hasOvero) return "/horse/silver overo buckskin.svg";
+    return "/horse/silver buckskin.svg";
+  }
+  if (colorName === "Silver Bay") {
+    const hasOvero = tags.includes("Frame Overo");
+    const hasRoan = tags.includes("Roan");
+    if (hasOvero) return "/horse/overo Silver bay.svg";
+    if (hasRoan) return "/horse/Silver bay roan.svg";
+    return "/horse/Silver bay.svg";
+  }
+  if (colorName === "Silver Black") {
+    if (tags.includes("Frame Overo")) return "/horse/silver overo black.svg";
+    return "/horse/black.svg";
   }
   if (colorName.includes("Pearl")) {
     if (tags.includes("Frame Overo")) return "/horse/Overo Pearl or Cream pearl.svg";


### PR DESCRIPTION
## Summary
- map additional coat color combinations like chestnut roan, palomino roan, silver buckskin overo, and more to their SVG images
- extend image map to include palomino and silver variants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd57332883209b82280e0c5d025a