### PR TITLE
Use black svg for smoky black base

### DIFF
--- a/src/components/HorseImage.tsx
+++ b/src/components/HorseImage.tsx
@@ -22,7 +22,10 @@ function toSlug(name: string): string {
 
 function getBaseSrc(colorName?: string, tags: string[] = []) {
   if (!colorName) return undefined;
-  const slug = toSlug(colorName);
+  let slug = toSlug(colorName);
+  if (slug === "smoky-black") {
+    slug = "black";
+  }
   const base = tags.includes("Roan") ? `${slug}-roan` : slug;
   return `${BASE_PATH}/${base}.svg`;
 }


### PR DESCRIPTION
## Summary
- render black base image when phenotype is Smoky Black

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Next.js interactive ESLint configuration prompt)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c38ec512508320893d3f3436b9c414